### PR TITLE
build: redis docker image 변경 및 환경변수 추가

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,3 +1,44 @@
 APP_NAME="Sample Application"
 SERVER_PORT=80
-MARIADB_ROOT_PASSWORD=1
+
+#######################################
+# MARIADB
+#######################################
+# MariaDb Host
+MARIADB_HOST="127.0.0.1"
+
+# MariaDb Port
+MARIADB_PORT=3306
+
+# MariaDb Database
+MARIADB_DATABASE=""
+
+# MariaDb User
+MARIADB_USER=""
+
+# MariaDb Password
+MARIADB_PASSWORD=""
+
+# MariaDb Connection Limit
+MARIADB_CONNECTION_LIMIT=5
+
+#######################################
+# MARIADB - ROOT
+#######################################
+# MariaDb Root Password
+MARIADB_ROOT_PASSWORD="1234"
+
+#######################################
+# REDIS
+#######################################
+# REDIS HOST
+REDIS_HOST="127.0.0.1"
+
+# REDIS PORT
+REDIS_PORT=6379
+
+# REDIS DATABASE
+REDIS_DB=0
+
+# REDIS AUTH
+REDIS_PASSWORD="1234"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: ./Dockerfile
     ports:
-      - 80:80
+      - "80:80"
     profiles:
       - dev
     env_file:
@@ -30,7 +30,7 @@ services:
       context: .
       dockerfile: ./Dockerfile
     ports:
-      - 80:80
+      - "80:80"
     profiles:
       - prod
     env_file:
@@ -76,9 +76,11 @@ services:
     restart: on-failure
 
   redis-dev:
-    image: redis:6.2-alpine
+    image: bitnami/redis:6.2
     ports:
-      - "6379"
+      - "6379:6379"
+    env_file:
+      - .env.dev
     profiles:
       - dev
       - infra-only
@@ -86,9 +88,11 @@ services:
       - backend
 
   redis-prod:
-    image: redis:6.2-alpine
+    image: bitnami/redis:6.2
     ports:
-      - "6379"
+      - "6379:6379"
+    env_file:
+      - .env
     profiles:
       - prod
     networks:


### PR DESCRIPTION
* 공식 Redis 이미지에서는 Auth 설정이 누락되어 있어서 Bitnami 에서 지원하는 이미지로 변경
* Redis 및 MariaDB 에서 필요로 하는 환경변수 추가